### PR TITLE
fix: use maven local instead of github

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -4,7 +4,8 @@ version '1.2.1'
 buildscript {
     repositories {
         google()
-        jcenter()
+        mavenCentral()
+        mavenLocal()
         maven { url "https://jitpack.io" }
     }
 
@@ -16,7 +17,8 @@ buildscript {
 rootProject.allprojects {
     repositories {
         google()
-        jcenter()
+        mavenCentral()
+        mavenLocal()
         maven { url "https://jitpack.io" }
         maven {
             url = 'https://maven.pkg.github.com/resideo/MultiPlatformBleAdapter'


### PR DESCRIPTION
This pull request updates the Gradle build configuration to improve dependency management by replacing the deprecated `jcenter()` repository with `mavenCentral()` and adding `mavenLocal()` as a repository source. These changes ensure more reliable access to dependencies and better compatibility with modern Gradle practices.

Repository configuration updates:

* Replaced `jcenter()` with `mavenCentral()` and added `mavenLocal()` in the `buildscript.repositories` block in `android/build.gradle` to modernize and expand dependency resolution sources.
* Made the same updates in the `allprojects.repositories` block in `android/build.gradle` for consistency across the project.